### PR TITLE
[chore] README update and ci update

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -51,3 +51,5 @@ jobs:
         run: cabal build
       - name: Test
         run: cabal test all
+      - name: Run cabal-audit on itself
+        run: cabal run cabal-audit

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
-  <h1> <code> cabal-audit </code> </h1>
   <a href="https://github.com/mangoiv/cabal-audit/actions">
     <img src="https://github.com/mangoiv/cabal-audit/actions/workflows/cabal-audit.yml/badge.svg" alt="CI">
   </a>
+  <h1> <code> cabal-audit </code> </h1>
 </div>
 
 `cabal-audit` is a command-line utility that scans Haskell projects for known vulnerabilities based on the 


### PR DESCRIPTION
runs cabal-audit on itself, reorders the badge and headline of the README