### PR TITLE
Adding possibility to exclude vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
   <h1> <code> cabal-audit </code> </h1>
 </div>
 
-`cabal-audit` is a command-line utility that scans Haskell projects for known vulnerabilities based on the 
-[security advisories database](https://github.com/haskell/security-advisories). 
-It checks project dependencies, reports potential vulnerabilities, and provides details about the vulnerabilities, including links to relevant 
+`cabal-audit` is a command-line utility that scans Haskell projects for known vulnerabilities based on the
+[security advisories database](https://github.com/haskell/security-advisories).
+It checks project dependencies, reports potential vulnerabilities, and provides details about the vulnerabilities, including links to relevant
 advisories and possible fixes.
 
 ## Installation
@@ -24,7 +24,7 @@ If you don't use `nix`, you can also build from source with `cabal`. Just clone 
 You can also [download a static executable from one of the latest workflow runs](https://github.com/MangoIV/cabal-audit/releases/tag/nightly).
 
 > [!Note]
-> We also have a `cachix`. If you trust me (which I do not recommend, never trust anybody!), run `cachix use cabal-audit` to 
+> We also have a `cachix`. If you trust me (which I do not recommend, never trust anybody!), run `cachix use cabal-audit` to
 > download directly from the cachix and skip building.
 
 ## Usage
@@ -35,9 +35,10 @@ Run `cabal-audit` to scan your project for known vulnerabilities:
 λ cabal-audit --help
 Welcome to cabal audit
 
-Usage: cabal-audit [(-p|--file-path FILEPATH) | (-r|--repository REPOSITORY)] 
-                   [--verbosity ARG] [-m|--json] [-o|--to-file FILEPATH] 
-                   [-b|--no-color|--no-colour] [--fail-on-warning]
+Usage: cabal-audit [(-p|--file-path FILEPATH) | (-r|--repository REPOSITORY)]
+                   [--verbosity ARG] [(-m|--json) | --sarif | --cyclonedx]
+                   [-o|--to-file FILEPATH] [-b|--no-color|--no-colour]
+                   [--fail-on-warning] [-x|--exclude-file FILEPATH]
 
   audit your cabal projects for vulnerabilities
 
@@ -50,11 +51,16 @@ Available options:
                            directory
   -m,--json                whether to format as json mapping package names to
                            osvs that apply
+  --sarif                  produce a sarif file (GitHub Code Scanning)
+  --cyclonedx              produce a CycloneDX SBOM
   -o,--to-file FILEPATH    specify a file to write to, instead of stdout
   -b,--no-color,--no-colour
                            don't colour the output
   --fail-on-warning        Exits with an error code if any advisories are found
                            in the build plan
+  -s,--suppress-file FILEPATH
+                           path to a JSON file listing suppressed advisories
+                           (default: ".cabal-audit.json")
 ```
 
 ```console
@@ -89,6 +95,33 @@ dependency "process" at version 1.6.18.0 is vulnerable for:
 > [!Note]
 > If you encounter an error related to lock file incompatibility, consider upgrading your Nix version.
 
+## Suppressing advisories with an exclusions file
+
+Sometimes a reported vulnerability is known not to affect your project (wrong
+platform, unused code path, mitigated in your deployment, etc.) and the team
+wants to silence the warning either permanently or until a decision is
+revisited.
+
+`cabal-audit` supports an *exclusions file* for this. By default it looks for
+`.cabal-audit.json` in the current directory; you can point it to a different
+location with `-s`/`--suppress-file`.
+
+The file is JSON:
+
+```json
+[
+  {
+    "id": "HSEC-2023-0007",
+    "reason": "we do not parse untrusted floating-point input"
+  },
+  {
+    "id": "HSEC-2024-0003",
+    "reason": "revisit when we ship a Windows build",
+    "expires": "2026-12-31"
+  }
+]
+```
+
 ## Using in Github action
 
 To scan for vulnerabilities and upload a [SARIF report for GitHub code scanning](https://docs.github.com/en/code-security/concepts/code-scanning/sarif-files), you can use [blackheaven/haskell-security-action](https://github.com/blackheaven/haskell-security-action). See its README for an example workflow.
@@ -99,12 +132,12 @@ After running on main branch, results should appear in `Security and quality` ->
 
 - query for vulnerable dependencies in cabal plan
 - human readable output
-- machine readable output 
+- machine readable output
 - fix version suggestion
 
 ## Contributing
 
-Contributions are welcome. 
+Contributions are welcome.
 
 Building the project in a non-nix environment should be as easy as `cabal build`, the build is tested against multiple ghc versions and operating systems in the CI so it should always work with one of these. If you don't use nix, installing the necessary tooling is as always possible with [ghcup](https://www.haskell.org/ghcup/).
 

--- a/cabal-audit.cabal
+++ b/cabal-audit.cabal
@@ -69,6 +69,7 @@ library
     Control.Effect.Pretty
     Distribution.Audit
     Security.Advisories.Cabal
+    Security.Advisories.Exclude
     Security.Advisories.SBom.Cabal
     Security.Advisories.SBom.CycloneDX
     Security.Advisories.SBom.Types
@@ -81,6 +82,7 @@ library
     , cabal-install
     , colourista
     , containers
+    , directory
     , filepath
     , fused-effects
     , hsec-core

--- a/src/Distribution/Audit.hs
+++ b/src/Distribution/Audit.hs
@@ -29,7 +29,7 @@ import Data.SARIF as Sarif
 import Data.String (IsString (fromString))
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Time (getCurrentTime)
+import Data.Time (getCurrentTime, utctDay)
 import Data.UUID.V4 qualified as UUID
 import Data.Vector (Vector)
 import Data.Vector qualified as V
@@ -59,6 +59,7 @@ import Security.Advisories.Cabal
   , matchAdvisoriesForPlan
   )
 import Security.Advisories.Convert.OSV qualified as OSV
+import Security.Advisories.Exclude
 import Security.Advisories.Filesystem (listAdvisories)
 import Security.Advisories.SBom.Cabal (planToSBom)
 import Security.Advisories.SBom.CycloneDX (CycloneDXInfo (..), serializeToCycloneDX)
@@ -82,6 +83,8 @@ data AuditException
     ListAdvisoryValidationError {parseError :: [(FilePath, ParseAdvisoryError)]}
   | -- | to rethrow exceptions thrown by cabal during plan elaboration
     CabalException {reason :: String, cabalException :: SomeException}
+  | -- | loading or parsing an exclusion file failed
+    ExcludeFileError {excludeFileError :: ExclusionsLoadError}
   deriving stock (Show, Generic)
 
 instance Exception AuditException where
@@ -102,6 +105,7 @@ instance Exception AuditException where
         <> ctx
         <> ":\n"
         <> displayException ex
+    ExcludeFileError err -> displayExclusionsLoadError err
 
 -- | the type of output that is chosen for the command
 data OutputFormat
@@ -128,6 +132,8 @@ data AuditConfig = MkAuditConfig
   -- ^ whether or not to write coloured output
   , failOnWarning :: Bool
   -- ^ whether to exit with a non-success code when advisories are found
+  , excludeFile :: FilePath
+  -- ^ path to a JSON exclusion file
   }
 
 data AuditResult = MkAuditResult
@@ -152,9 +158,16 @@ auditMain = do
   runM $ interpPretty do
     advisories <-
       ( do
+          exclusions <- do
+            liftIO (loadExclusions (excludeFile auditConfig)) >>= \case
+              Left err -> throwIO (ExcludeFileError err)
+              Right exs -> pure exs
           result <- buildAdvisories auditConfig nixStyleFlags
-          handleBuiltAdvisories result (outputHandle auditConfig) (outputFormat auditConfig)
-          pure result.auditResult'advisories
+          today <- liftIO $ utctDay <$> getCurrentTime
+          let filteredAdvisories = applyExclusions today exclusions result.auditResult'advisories
+              filteredResult = result {auditResult'advisories = filteredAdvisories}
+          handleBuiltAdvisories filteredResult (outputHandle auditConfig) (outputFormat auditConfig)
+          pure filteredAdvisories
       )
         `catch` \(SomeException ex) -> do
           owo
@@ -535,6 +548,15 @@ auditCommandParser =
           mconcat
             [ long "fail-on-warning"
             , help "Exits with an error code if any advisories are found in the build plan"
+            ]
+        <*> strOption do
+          mconcat
+            [ long "suppress-file"
+            , short 's'
+            , metavar "FILEPATH"
+            , value ".cabal-audit.json"
+            , showDefault
+            , help "path to a JSON file listing suppressed advisories"
             ]
     -- FUTUREWORK(mangoiv): this will accept cabal flags as an additional argument with something like
     -- --cabal-flags "--some-cabal-flag" and print a helper that just forwards the cabal help text

--- a/src/Security/Advisories/Exclude.hs
+++ b/src/Security/Advisories/Exclude.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE StrictData #-}
+
+module Security.Advisories.Exclude
+  ( Exclude (..)
+  , ExclusionsLoadError (..)
+  , loadExclusions
+  , applyExclusions
+  , displayExclusionsLoadError
+  )
+where
+
+import Data.Aeson (FromJSON (..), withObject, (.:), (.:?))
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as BSL
+import Data.Functor.Identity (Identity (Identity, runIdentity))
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Time (Day)
+import GHC.Generics (Generic)
+import Security.Advisories (Advisory (advisoryId))
+import Security.Advisories.Cabal
+  ( AuditedComponent
+  , ElaboratedPackageInfoAdvised
+  , ElaboratedPackageInfoWith (..)
+  )
+import Security.Advisories.Core.HsecId (HsecId, parseHsecId)
+import System.Directory (doesFileExist)
+
+data Exclude = MkExclude
+  { exclude'id :: HsecId
+  , exclude'reason :: Text
+  , exclude'expires :: Maybe Day
+  }
+  deriving stock (Eq, Show, Generic)
+
+instance FromJSON Exclude where
+  parseJSON = withObject "Exclude" \o -> do
+    idText :: Text <- o .: "id"
+    exclude'id <- maybe (fail ("invalid HSEC id: " <> T.unpack idText)) pure $ parseHsecId (T.unpack idText)
+    exclude'reason <- o .: "reason"
+    exclude'expires <- o .:? "expires"
+    pure MkExclude {exclude'id, exclude'reason, exclude'expires}
+
+data ExclusionsLoadError
+  = ExclusionsFileParseError FilePath String
+  deriving stock (Eq, Show, Generic)
+
+displayExclusionsLoadError :: ExclusionsLoadError -> String
+displayExclusionsLoadError = \case
+  ExclusionsFileParseError fp err ->
+    "Failed to parse exclusion file " <> fp <> ":\n" <> err
+
+loadExclusions :: FilePath -> IO (Either ExclusionsLoadError [Exclude])
+loadExclusions path = do
+  exists <- doesFileExist path
+  if not exists
+    then pure (Right mempty)
+    else do
+      bs <- BSL.readFile path
+      pure $ either (Left . ExclusionsFileParseError path) Right $ Aeson.eitherDecode bs
+
+applyExclusions
+  :: Day
+  -> [Exclude]
+  -> Map AuditedComponent ElaboratedPackageInfoAdvised
+  -> Map AuditedComponent ElaboratedPackageInfoAdvised
+applyExclusions today exs =
+  let activeIds :: Set HsecId
+      activeIds =
+        Set.fromList [exclude'id e | e <- exs, not (isExpired today e)]
+
+      keepAdvisory (adv, _) = not (Set.member (advisoryId adv) activeIds)
+
+      filterPackage info =
+        let kept = filter keepAdvisory (runIdentity (packageAdvisories info))
+         in if null kept
+              then Nothing
+              else Just info {packageAdvisories = Identity kept}
+   in Map.mapMaybe filterPackage
+
+isExpired :: Day -> Exclude -> Bool
+isExpired today MkExclude {exclude'expires} =
+  case exclude'expires of
+    Nothing -> False
+    Just d -> d < today


### PR DESCRIPTION
Sometimes a reported vulnerability is known not to affect your project (wrong
platform, unused code path, mitigated in your deployment, etc.) and the team
wants to silence the warning either permanently or until a decision is
revisited.